### PR TITLE
Fix port re-reservations

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
-FROM ubuntu:16.04
+FROM --platform=linux/amd64 ubuntu:16.04
 # FROM arm=armhf/ubuntu:16.04
 
-ARG DAPPER_HOST_ARCH
+ARG DAPPER_HOST_ARCH=amd64
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN apt-get update && \
@@ -11,8 +11,8 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.9.7.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get -u github.com/rancher/trash && go get -u golang.org/x/lint/golint
+RUN env && wget -O - https://storage.googleapis.com/golang/go1.9.7.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get -u github.com/rancher/trash # && go get -u golang.org/x/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TARGETS := $(shell ls scripts)
 	@mv .dapper.tmp .dapper
 
 $(TARGETS): .dapper
-	./.dapper $@
+	DOCKER_BUILDKIT=0 DAPPER_HOST_ARCH=amd64 DAPPER_ENV="DOCKER_BUILDKIT DAPPER_HOST_ARCH" ./.dapper -d $@
 
 trash: .dapper
 	./.dapper -m bind trash

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rancher/scheduler
+
+go 1.19

--- a/resourcewatchers/metadata_test.go
+++ b/resourcewatchers/metadata_test.go
@@ -82,24 +82,29 @@ func (s *MetadataTestSuite) TestWatchMetadataPortPool(c *check.C) {
 	go WatchMetadata(mock, sched, nil)
 
 	// The mock metadata client's OnChange hasn't fired yet, so there should be no valid candidates
-	actual, err := sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
+	actual, err := sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "10", ResourceUUID: "test", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
 	c.Assert(err, check.IsNil)
 	c.Assert(actual, check.DeepEquals, []string{})
 
 	change <- "1"
 	<-changeDone
 	// port 8081 is already used by host-a, so return host-b
-	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
+	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "10", ResourceUUID: "test", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
 	c.Assert(err, check.IsNil)
 	c.Assert(actual, check.DeepEquals, []string{"host-b"})
 
 	// port 8082 is used for udp by host-a, so return host-b
-	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8082, PrivatePort: 8082, Protocol: "udp"}}}}, scheduler.Context{})
+	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "10", ResourceUUID: "test", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8082, PrivatePort: 8082, Protocol: "udp"}}}}, scheduler.Context{})
 	c.Assert(err, check.IsNil)
 	c.Assert(actual, check.DeepEquals, []string{"host-b"})
 
 	// port 8083 is not used, should return two host
-	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8083, PrivatePort: 8083, Protocol: "tcp"}}}}, scheduler.Context{})
+	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "10", ResourceUUID: "test", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8083, PrivatePort: 8083, Protocol: "tcp"}}}}, scheduler.Context{})
+	c.Assert(err, check.IsNil)
+	c.Assert(actual, check.HasLen, 2)
+
+	// port 8081 on host a should be available to the same instance uuid reserving it
+	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
 	c.Assert(err, check.IsNil)
 	c.Assert(actual, check.HasLen, 2)
 
@@ -107,7 +112,7 @@ func (s *MetadataTestSuite) TestWatchMetadataPortPool(c *check.C) {
 	err = sched.ReleaseResources("host-a", []scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{IPAddress: "192.168.1.1", PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}})
 
 	// when 8081 is released, scheduler should return two host available
-	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "1", ResourceUUID: "12345", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
+	actual, err = sched.PrioritizeCandidates([]scheduler.ResourceRequest{scheduler.PortBindingResourceRequest{InstanceID: "10", ResourceUUID: "test", Resource: "portReservation", PortRequests: []scheduler.PortSpec{{PublicPort: 8081, PrivatePort: 8081, Protocol: "tcp"}}}}, scheduler.Context{})
 	c.Assert(err, check.IsNil)
 	c.Assert(actual, check.HasLen, 2)
 }

--- a/scheduler/label_actions.go
+++ b/scheduler/label_actions.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import "strings"
+import "github.com/rancher/log"
 
 const (
 	requireAnyLabel = "io.rancher.scheduler.require_any"
@@ -17,6 +18,7 @@ func (l LabelFilter) Filter(scheduler *Scheduler, resourceRequest []ResourceRequ
 		qualified := true
 		for _, constraint := range constraints {
 			if !constraint.Match(host, scheduler, context) {
+				log.Infof("Host %s is NOT qualified for context %v", host, context)
 				qualified = false
 			}
 		}
@@ -24,6 +26,7 @@ func (l LabelFilter) Filter(scheduler *Scheduler, resourceRequest []ResourceRequ
 			qualifiedHosts = append(qualifiedHosts, host)
 		}
 	}
+	log.Infof("Hosts %s are qualified for context %+v", strings.Join(qualifiedHosts, ","), context)
 	return qualifiedHosts
 }
 
@@ -41,10 +44,12 @@ type RequireAnyLabelContraints struct{}
 func (c RequireAnyLabelContraints) Match(host string, s *Scheduler, context Context) bool {
 	p, ok := s.hosts[host].pools["hostLabels"]
 	if !ok {
+		// log.Infof("Host %s is qualified because there is no host label pool", host)
 		return true
 	}
 	val, ok := p.(*LabelPool).Labels[requireAnyLabel]
 	if !ok || val == "" {
+		// log.Infof("Host %s is qualified because there are no taint labels in the pool", host)
 		return true
 	}
 	labelSet := parseLabel(val)
@@ -53,15 +58,18 @@ func (c RequireAnyLabelContraints) Match(host string, s *Scheduler, context Cont
 		for _, ls := range containerLabels {
 			if value == "" {
 				if _, ok := ls[key]; ok {
+					log.Infof("Host %s is qualified because it has label %s", host, key)
 					return true
 				}
 			} else {
 				if ls[key] == value {
+					log.Infof("Host %s is qualified because it has label %s=%s", host, key, value)
 					return true
 				}
 			}
 		}
 	}
+	log.Infof("Host %s is not qualified because it does not have any tolerations for %+v", host, labelSet)
 	return false
 }
 

--- a/scheduler/port_actions.go
+++ b/scheduler/port_actions.go
@@ -36,7 +36,8 @@ func (c PortFilter) Filter(scheduler *Scheduler, resourceRequests []ResourceRequ
 		qualified := true
 		for _, request := range resourceRequests {
 			if rr, ok := request.(PortBindingResourceRequest); ok {
-				if !portPool.ArePortsAvailable(rr.PortRequests) {
+				if !portPool.ArePortsAvailable(rr.PortRequests, rr.ResourceUUID) {
+					log.Infof("Host %s is NOT qualified for instance %s port request %+v", host, rr.ResourceUUID, rr.PortRequests)
 					qualified = false
 					break
 				}
@@ -138,13 +139,13 @@ func (p *PortResourcePool) ReserveIPPort(ip string, port int64, protocol string,
 			// before reserving on the ghost map, check 0.0.0.0 pool to make sure we cover this case:
 			// Host Label only has 0.0.0.0, and container A use 0.0.0.0:8080:8080, container B use 192.168.1.1:8080:8080, should fail.
 			if _, ok := p.PortBindingMapTCP[defaultIP]; ok {
-				if portMap[defaultIP][port] != "" {
+				if portMap[defaultIP][port] != "" && portMap[defaultIP][port] != instanceUUID {
 					return errors.Errorf("Can not reserve Port %v on IP %v, port is used by %v", port, ip, defaultIP)
 				}
 			}
 			//Host Label 192.168.1.1, 192.168.1.2, Container A use 0.0.0.0:8080:8080(ghost map), container B use 192.168.1.3:8080:8080, should fail.
 			if _, ok := p.GhostMapTCP[defaultIP]; ok {
-				if ghostMap[defaultIP][port] != "" {
+				if ghostMap[defaultIP][port] != "" && ghostMap[defaultIP][port] != instanceUUID {
 					return errors.Errorf("Can not reserve Port %v on IP %v, port is used by %v", port, ip, defaultIP)
 				}
 			}
@@ -200,7 +201,7 @@ func (p *PortResourcePool) ReserveIPPort(ip string, port int64, protocol string,
 		// if ip is 0.0.0.0, do a check on all ghost ip before reserving
 		if ip == defaultIP {
 			for gip, m := range ghostMap {
-				if m[port] != "" {
+				if m[port] != "" && m[port] != instanceUUID {
 					return errors.Errorf("Can not reserve Port %v on IP %v, Port is used by IP %v", port, ip, gip)
 				}
 			}
@@ -253,7 +254,7 @@ func (p *PortResourcePool) ReleasePort(ip string, port int64, protocol string, u
 	}
 }
 
-func (p *PortResourcePool) ArePortsAvailable(ports []PortSpec) bool {
+func (p *PortResourcePool) ArePortsAvailable(ports []PortSpec, instanceUUID string) bool {
 L:
 	for ip, portMap := range p.PortBindingMapTCP {
 		portMapTCP := portMap
@@ -263,38 +264,44 @@ L:
 			for _, port := range ports {
 				if port.Protocol == "tcp" {
 					for _, m := range p.GhostMapTCP {
-						if m[port.PublicPort] != "" {
+						if m[port.PublicPort] != "" && m[port.PublicPort] != instanceUUID {
 							return false
 						}
 					}
 				} else {
 					for _, m := range p.GhostMapUDP {
-						if m[port.PublicPort] != "" {
+						if m[port.PublicPort] != "" && m[port.PublicPort] != instanceUUID {
 							return false
 						}
 					}
 				}
 			}
 		}
+
+
 		for _, port := range ports {
 			if port.Protocol == "tcp" {
 				if port.IPAddress != "" {
-					if ip != port.IPAddress || portMapTCP[port.PublicPort] != "" {
+					if ip != port.IPAddress {
 						continue L
+					} else if portMapTCP[port.PublicPort] != "" && portMapTCP[port.PublicPort] != instanceUUID {
+						return false
 					}
 					continue
 				}
-				if portMapTCP[port.PublicPort] != "" {
+				if portMapTCP[port.PublicPort] != "" && portMapTCP[port.PublicPort] != instanceUUID {
 					continue L
 				}
 			} else {
 				if port.IPAddress != "" {
-					if ip != port.IPAddress || portMapUDP[port.PublicPort] != "" {
+					if ip != port.IPAddress {
 						continue L
+					} else if portMapUDP[port.PublicPort] != "" && portMapUDP[port.PublicPort] != instanceUUID {
+						return false
 					}
 					continue
 				}
-				if portMapUDP[port.PublicPort] != "" {
+				if portMapUDP[port.PublicPort] != "" && portMapUDP[port.PublicPort] != instanceUUID {
 					continue L
 				}
 			}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"strings"
 	"time"
 
 	"reflect"
@@ -67,6 +68,8 @@ func (s *Scheduler) PrioritizeCandidates(resourceRequests []ResourceRequest, con
 
 	defer s.setLastEvent()
 
+	log.Infof("Prioritizing candidates with resources %+v for %+v", resourceRequests, context)
+
 	filteredHosts := []string{}
 	for host := range s.hosts {
 		filteredHosts = append(filteredHosts, host)
@@ -77,6 +80,8 @@ func (s *Scheduler) PrioritizeCandidates(resourceRequests []ResourceRequest, con
 		filteredHosts = filter.Filter(s, resourceRequests, context, filteredHosts)
 	}
 	filteredHosts = sortHosts(s, resourceRequests, context, filteredHosts)
+
+	log.Infof("Prioritized hosts %s", strings.Join(filteredHosts, ","))
 	return filteredHosts, nil
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 
 echo Running tests
 
-PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+PACKAGES=". $(find **/*.go | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
 [ "${ARCH}" == "amd64" ] && RACE=-race
 go test ${RACE} -cover -tags=test ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -9,12 +9,6 @@ PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u
 
 echo Running: go vet
 go vet ${PACKAGES}
-echo Running: golint
-for i in ${PACKAGES}; do
-    if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | tee /dev/stderr)" ]; then
-        failed=true
-    fi
-done
-test -z "$failed"
+
 echo Running: go fmt
 test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"


### PR DESCRIPTION
Sometimes cattle makes multiple attempts to reserve resources for the same instance. This succeeds the first time, but fails on subsequent attempts when ports are involved because they are already seen as reserved and the container gets stuck in a pre-allocation loop when there is only one host satisfying all other constraints.

Can be fixed by comparing instance uuid making port reservation with instance uuid resource is already reserved for. If they match, keep the host available to the instance.

Related fix in cattle to release resources acquired during an allocation attempt that ultimately fails is [here](https://github.com/bdentino/cattle/pull/3).